### PR TITLE
Refactor meta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ build:
 	cargo build
 
 test:
-	cargo test
+	RUST_BACKTRACE=full cargo test
 
 lint:
 	find src -name "*.rs" | xargs rustup run stable rustfmt

--- a/docs/design.md
+++ b/docs/design.md
@@ -60,26 +60,18 @@ If node B fails, the coordinators should create a new one and tell node A to cha
 # Control Commands
 
 - nmctl listdb
-- nmctl cleardb
 - ping
 - cluster nodes
 - cluster slots
 ### nmctl setdb
 
-- nmctl setdb epoch flags [dbname1 ip:port slot_range] ...
+- nmctl setdb epoch flags [dbname1 ip:port slot_range] [PEER [dbname1 ip:port slot_range]] ...
 - `epoch` is the epoch of host
 - `flags` is reserved. Currently it may be NOFLAG or FORCE. In the future if we add more flags, separate them by ','.
 - `slot_range` can be
     - 0-1000
     - migrating dst_ip:dst_port 0-1000
     - importing src_ip:src_port 0-1000
-
-### nmctl setpeer
-
-- nmctl setpeer epoch flags [dbname1 ip:port slot_range] ...
-- `epoch` is the epoch of host
-- `flags` is reserved. Currently it may be NOFLAG or FORCE.
-- `slot_range` can be in the form of 0-1000
 
 # Epoch
 

--- a/examples/failover/checker.py
+++ b/examples/failover/checker.py
@@ -80,17 +80,15 @@ def send_config(address, slots_config, nodes_config):
     for start, end in slots_config[address]:
         setdb.extend([DB_NAME, nodes_config[address], '{}-{}'.format(start, end)])
 
-    setpeer = ['UMCTL', 'SETPEER', '1', 'FORCE']
+    setdb.append('PEER')
     for node, slots in slots_config.items():
         if node == address:
             continue
         for start, end in slots:
-            setpeer.extend([DB_NAME, node, '{}-{}'.format(start, end)])
+            setdb.extend([DB_NAME, node, '{}-{}'.format(start, end)])
 
     logger.info('sending setdb: %s', setdb)
-    logger.info('sending setpeer: %s', setpeer)
     client.execute_command(*setdb)
-    client.execute_command(*setpeer)
 
 
 def run_checker(init_nodes_config, init_slots_config):

--- a/examples/mem-broker/init.py
+++ b/examples/mem-broker/init.py
@@ -5,9 +5,6 @@ def init_hosts():
         'server_proxy1:6001': ['redis1:6379', 'redis2:6379'],
         'server_proxy2:6002': ['redis3:6379', 'redis4:6379'],
         'server_proxy3:6003': ['redis5:6379', 'redis6:6379'],
-        'server_proxy4:6004': ['redis7:6379', 'redis8:6379'],
-        'server_proxy5:6005': ['redis9:6379', 'redis10:6379'],
-        'server_proxy6:6006': ['redis11:6379', 'redis12:6379'],
     }
     for proxy_address, node_addresses in hosts.items():
         add_host(proxy_address, node_addresses)

--- a/examples/multi-shard/init.sh
+++ b/examples/multi-shard/init.sh
@@ -24,10 +24,6 @@ for i in "${!proxy_list[@]}"; do
     done
 done
 
-redis-cli -h server_proxy1 -p 6001 UMCTL SETDB 1 FORCE mydb redis1:6379 0-5461
-redis-cli -h server_proxy2 -p 6002 UMCTL SETDB 1 FORCE mydb redis2:6379 5462-10922
-redis-cli -h server_proxy3 -p 6003 UMCTL SETDB 1 FORCE mydb redis3:6379 10923-16383
-
-redis-cli -h server_proxy1 -p 6001 UMCTL SETPEER 1 FORCE mydb server_proxy2:6002 5462-10922 mydb server_proxy3:6003 10923-16383
-redis-cli -h server_proxy2 -p 6002 UMCTL SETPEER 1 FORCE mydb server_proxy1:6001 0-5461 mydb server_proxy3:6003 10923-16383
-redis-cli -h server_proxy3 -p 6003 UMCTL SETPEER 1 FORCE mydb server_proxy1:6001 0-5461 mydb server_proxy2:6002 5462-10922
+redis-cli -h server_proxy1 -p 6001 UMCTL SETDB 1 FORCE mydb redis1:6379 0-5461 PEER mydb server_proxy2:6002 5462-10922 mydb server_proxy3:6003 10923-16383
+redis-cli -h server_proxy2 -p 6002 UMCTL SETDB 1 FORCE mydb redis2:6379 5462-10922 PEER mydb server_proxy1:6001 0-5461 mydb server_proxy3:6003 10923-16383
+redis-cli -h server_proxy3 -p 6003 UMCTL SETDB 1 FORCE mydb redis3:6379 10923-16383 PEER mydb server_proxy1:6001 0-5461 mydb server_proxy2:6002 5462-10922

--- a/src/common/db.rs
+++ b/src/common/db.rs
@@ -44,7 +44,6 @@ impl DBMapFlags {
 }
 
 const PEER_PREFIX: &str = "PEER";
-const REPL_PREFIX: &str = "REPL";
 
 #[derive(Debug, Clone)]
 pub struct ProxyDBMeta {
@@ -85,7 +84,7 @@ impl ProxyDBMeta {
             _ => return Err(CmdParseError {}),
         };
 
-        // Skip the "UMCTL SET_DB"
+        // Skip the "UMCTL SETDB"
         let it = arr.iter().skip(2).flat_map(|resp| match resp {
             Resp::Bulk(BulkStr::Str(safe_str)) => match str::from_utf8(safe_str) {
                 Ok(s) => Some(s.to_string()),
@@ -112,8 +111,6 @@ impl ProxyDBMeta {
         while let Some(token) = it.next() {
             if token.to_uppercase() == PEER_PREFIX {
                 peer = HostDBMap::parse(it)?;
-            } else if token.to_uppercase() == REPL_PREFIX {
-                // TODO: move replication here
             } else {
                 return Err(CmdParseError {});
             }
@@ -136,7 +133,6 @@ impl ProxyDBMeta {
             args.push(PEER_PREFIX.to_string());
             args.extend_from_slice(&peer);
         }
-        //        args.push(REPL_PREFIX.to_string());
         args
     }
 }
@@ -203,7 +199,7 @@ impl HostDBMap {
             match it.peek() {
                 Some(first_token) => {
                     let prefix = first_token.to_uppercase();
-                    if prefix == PEER_PREFIX || prefix == REPL_PREFIX {
+                    if prefix == PEER_PREFIX {
                         break;
                     }
                 }

--- a/src/coordinator/sync.rs
+++ b/src/coordinator/sync.rs
@@ -125,22 +125,26 @@ impl<B: MetaDataBroker> HostMetaRetriever for BrokerMetaRetriever<B> {
     }
 }
 
-fn generate_host_meta_cmd_args( flags: DBMapFlags, local_proxy: Host, peer_proxy: Host) -> Vec<String> {
+fn generate_host_meta_cmd_args(
+    flags: DBMapFlags,
+    local_proxy: Host,
+    peer_proxy: Host,
+) -> Vec<String> {
     let epoch = local_proxy.get_epoch();
-//    let mut db_map: HashMap<String, HashMap<String, Vec<SlotRange>>> = HashMap::new();
-//    for node in host.into_nodes() {
-//        let dbs = db_map
-//            .entry(node.get_cluster_name().clone())
-//            .or_insert_with(HashMap::new);
-//        dbs.insert(node.get_address().clone(), node.into_slots().clone());
-//    }
+    //    let mut db_map: HashMap<String, HashMap<String, Vec<SlotRange>>> = HashMap::new();
+    //    for node in host.into_nodes() {
+    //        let dbs = db_map
+    //            .entry(node.get_cluster_name().clone())
+    //            .or_insert_with(HashMap::new);
+    //        dbs.insert(node.get_address().clone(), node.into_slots().clone());
+    //    }
     let local = generate_proxy_db_map(local_proxy);
     let peer = generate_proxy_db_map(peer_proxy);
     let proxy_db_meta = ProxyDBMeta::new(epoch, flags.clone(), local, peer);
-//    let args = HostDBMap::new(epoch, flags.clone(), db_map).db_map_to_args();
-//    let mut cmd = vec![epoch.to_string(), flags.to_arg()];
-//    cmd.extend(args.into_iter());
-//    cmd
+    //    let args = HostDBMap::new(epoch, flags.clone(), db_map).db_map_to_args();
+    //    let mut cmd = vec![epoch.to_string(), flags.to_arg()];
+    //    cmd.extend(args.into_iter());
+    //    cmd
     proxy_db_meta.to_args()
 }
 

--- a/src/migration/manager.rs
+++ b/src/migration/manager.rs
@@ -134,7 +134,7 @@ where
         self.task_map
             .iter()
             .map(|(db_name, tasks)| {
-                let mut lines = vec![db_name.to_string()];
+                let mut lines = vec![format!("name: {}", db_name)];
                 for task_meta in tasks.keys() {
                     if let Some(migration_meta) = task_meta.slot_range.tag.get_migration_meta() {
                         lines.push(format!(
@@ -151,7 +151,7 @@ where
                 lines.join("\n")
             })
             .collect::<Vec<String>>()
-            .join("\n\n")
+            .join("\r\n")
     }
 
     pub fn send(

--- a/src/migration/manager.rs
+++ b/src/migration/manager.rs
@@ -130,6 +130,30 @@ where
         }
     }
 
+    pub fn info(&self) -> String {
+        self.task_map
+            .iter()
+            .map(|(db_name, tasks)| {
+                let mut lines = vec![db_name.to_string()];
+                for task_meta in tasks.keys() {
+                    if let Some(migration_meta) = task_meta.slot_range.tag.get_migration_meta() {
+                        lines.push(format!(
+                            "{}-{} {} -> {}",
+                            task_meta.slot_range.start,
+                            task_meta.slot_range.end,
+                            migration_meta.src_node_address,
+                            migration_meta.dst_node_address
+                        ));
+                    } else {
+                        error!("invalid slot range migration meta");
+                    }
+                }
+                lines.join("\n")
+            })
+            .collect::<Vec<String>>()
+            .join("\n\n")
+    }
+
     pub fn send(
         &self,
         cmd_task: <<TSF as CmdTaskSenderFactory>::Sender as CmdTaskSender>::Task,

--- a/src/proxy/database.rs
+++ b/src/proxy/database.rs
@@ -228,7 +228,7 @@ impl<F: CmdTaskSenderFactory> Database<F> {
     pub fn info(&self) -> String {
         let mut lines = vec![
             format!("name: {}", self.name),
-            format!("epoch {}", self.epoch),
+            format!("epoch: {}", self.epoch),
             "nodes:".to_string(),
         ];
         for (node, slot_ranges) in self.slot_ranges.iter() {

--- a/src/proxy/executor.rs
+++ b/src/proxy/executor.rs
@@ -305,7 +305,7 @@ impl<F: RedisClientFactory> CmdCtxHandler for ForwardHandler<F> {
                 cmd_ctx.set_resp_result(Ok(Resp::Simple(String::from("OK").into_bytes())))
             }
             CmdType::Info => cmd_ctx.set_resp_result(Ok(Resp::Bulk(BulkStr::Str(
-                String::from("version:dev\r\n").into_bytes(),
+                format!("version:dev\r\n\r\n{}", self.manager.info()).into_bytes(),
             )))),
             CmdType::Auth => self.handle_auth(cmd_ctx),
             CmdType::Quit => {

--- a/src/proxy/executor.rs
+++ b/src/proxy/executor.rs
@@ -9,7 +9,7 @@ use ::migration::manager::SwitchError;
 use ::migration::task::parse_tmp_switch_command;
 use atoi::atoi;
 use caseless;
-use common::db::{ProxyDBMeta};
+use common::db::ProxyDBMeta;
 use common::utils::{
     get_element, ThreadSafe, NOT_READY_FOR_SWITCHING_REPLY, OLD_EPOCH_REPLY, TRY_AGAIN_REPLY,
 };
@@ -152,8 +152,6 @@ impl<F: RedisClientFactory> ForwardHandler<F> {
             cmd_ctx.set_resp_result(Ok(Resp::Arr(Array::Arr(resps))));
         } else if sub_cmd.eq("SETDB") {
             self.handle_umctl_setdb(cmd_ctx);
-//        } else if sub_cmd.eq("SETPEER") {
-//            self.handle_umctl_setpeer(cmd_ctx);
         } else if sub_cmd.eq("SETREPL") {
             self.handle_umctl_setrepl(cmd_ctx);
         } else if sub_cmd.eq("INFOREPL") {
@@ -182,7 +180,7 @@ impl<F: RedisClientFactory> ForwardHandler<F> {
             }
         };
 
-        match self.manager.set_db(db_meta) {
+        match self.manager.set_meta(db_meta) {
             Ok(()) => {
                 debug!("Successfully update local meta data");
                 cmd_ctx.set_resp_result(Ok(Resp::Simple("OK".to_string().into_bytes())));
@@ -195,34 +193,6 @@ impl<F: RedisClientFactory> ForwardHandler<F> {
             },
         }
     }
-
-//    fn handle_umctl_setpeer(&self, cmd_ctx: CmdCtx) {
-//        let db_map = match HostDBMap::from_resp(cmd_ctx.get_cmd().get_resp()) {
-//            Ok(db_map) => db_map,
-//            Err(_) => {
-//                cmd_ctx.set_resp_result(Ok(Resp::Error(
-//                    String::from("Invalid arguments").into_bytes(),
-//                )));
-//                return;
-//            }
-//        };
-//
-//        match self.manager.set_peers(db_map) {
-//            Ok(()) => {
-//                info!("Successfully update peer meta data");
-//                cmd_ctx.set_resp_result(Ok(Resp::Simple(String::from("OK").into_bytes())));
-//            }
-//            Err(e) => {
-//                //                debug!("Failed to update peer meta data {:?}", e);
-//                match e {
-//                    DBError::OldEpoch => cmd_ctx
-//                        .set_resp_result(Ok(Resp::Error(OLD_EPOCH_REPLY.to_string().into_bytes()))),
-//                    DBError::TryAgain => cmd_ctx
-//                        .set_resp_result(Ok(Resp::Error(TRY_AGAIN_REPLY.to_string().into_bytes()))),
-//                }
-//            }
-//        }
-//    }
 
     fn handle_umctl_setrepl(&self, cmd_ctx: CmdCtx) {
         let meta = match ReplicatorMeta::from_resp(cmd_ctx.get_cmd().get_resp()) {

--- a/src/proxy/slowlog.rs
+++ b/src/proxy/slowlog.rs
@@ -17,7 +17,6 @@ pub enum TaskEvent {
 
     SentToMigrationManager = 1,
     SentToMigrationDB = 2,
-    SentToMigrationTmpDB = 3,
     SentToDB = 4,
 
     SentToWritingQueue = 5,
@@ -193,10 +192,6 @@ fn slowlog_to_report(log: &Slowlog) -> Resp {
         format!(
             "sent_to_migration_db: {}",
             log.event_map.get_used_time(TaskEvent::SentToMigrationDB)
-        ),
-        format!(
-            "sent_to_migration_tmp_db: {}",
-            log.event_map.get_used_time(TaskEvent::SentToMigrationTmpDB)
         ),
         format!(
             "sent_to_db: {}",

--- a/src/proxy/slowlog.rs
+++ b/src/proxy/slowlog.rs
@@ -15,18 +15,17 @@ const MAX_ELEMENT_LENGTH: usize = 100;
 pub enum TaskEvent {
     Created = 0,
 
-    SentToMigrationManager = 1,
-    SentToMigrationDB = 2,
-    SentToDB = 4,
+    SentToMigrationDB = 1,
+    SentToDB = 2,
 
-    SentToWritingQueue = 5,
-    WritingQueueReceived = 6,
-    SentToBackend = 7,
-    ReceivedFromBackend = 8,
-    WaitDone = 9,
+    SentToWritingQueue = 3,
+    WritingQueueReceived = 4,
+    SentToBackend = 5,
+    ReceivedFromBackend = 6,
+    WaitDone = 7,
 }
 
-const EVENT_NUMBER: usize = 10;
+const EVENT_NUMBER: usize = 8;
 const LOG_ELEMENT_NUMBER: usize = 5;
 
 #[derive(Debug)]
@@ -57,7 +56,7 @@ impl RequestEventMap {
 impl Default for RequestEventMap {
     fn default() -> Self {
         Self {
-            events: arr![atomic::AtomicI64::new(0); 10],
+            events: arr![atomic::AtomicI64::new(0); 8],
         }
     }
 }
@@ -184,11 +183,6 @@ fn slowlog_to_report(log: &Slowlog) -> Resp {
     let elements = vec![
         format!("session_id: {}", log.session_id),
         format!("created: {}", start_date),
-        format!(
-            "sent_to_migration_manager: {}",
-            log.event_map
-                .get_used_time(TaskEvent::SentToMigrationManager)
-        ),
         format!(
             "sent_to_migration_db: {}",
             log.event_map.get_used_time(TaskEvent::SentToMigrationDB)


### PR DESCRIPTION
At the very beginning, I thought I should separate the following sub-metadata:
- (1) local nodes
- (2) peer proxies
- (3) migration
- (4) replication

Later when implementing the migration, I find it hard to guarantee that during the migration, the keys are all redirected correctly without keeping the first 3 metadata altogether. We need to use quite a bit of hacky techniques to achieve that.

Now for easy maintenance, we group the first 3 metadata together.