### PR TITLE
Fix cluster nodes format

### DIFF
--- a/src/common/resp_execution.rs
+++ b/src/common/resp_execution.rs
@@ -97,10 +97,7 @@ pub fn keep_connecting_and_sending<T: Send + Clone, F: RedisClientFactory, Func>
 where
     Func: Clone
         + Send
-        + Fn(
-            T,
-            F::Client,
-        ) -> Box<dyn Future<Item = (T, F::Client), Error = RedisClientError> + Send>,
+        + Fn(T, F::Client) -> Box<dyn Future<Item = (T, F::Client), Error = RedisClientError> + Send>,
 {
     let infinite_stream = stream::iter_ok(iter::repeat(()));
     infinite_stream.fold(data, move |data, ()| {

--- a/src/proxy/database.rs
+++ b/src/proxy/database.rs
@@ -497,8 +497,8 @@ fn gen_cluster_slots_helper(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::iter::repeat;
     use ::common::cluster::MigrationMeta;
+    use std::iter::repeat;
 
     fn gen_testing_slot_ranges(address: &str) -> HashMap<String, Vec<SlotRange>> {
         let mut slot_ranges = HashMap::new();

--- a/src/proxy/slot.rs
+++ b/src/proxy/slot.rs
@@ -65,7 +65,7 @@ impl SlotMapData {
 
     pub fn get(&self, slot: usize) -> Option<String> {
         let addr_index = self.slot_arr.get(slot).and_then(|opt| *opt)?;
-        self.addrs.get(addr_index).and_then(|s| Some(s.clone()))
+        self.addrs.get(addr_index).cloned()
     }
 }
 

--- a/src/replication/replicator.rs
+++ b/src/replication/replicator.rs
@@ -247,5 +247,4 @@ mod tests {
         let args = encode_repl_meta(meta.clone()).join(" ");
         assert_eq!(args, "233 NOFLAG master testdb localhost:6000 1 localhost:6001 localhost:5299 replica testdb localhost:6001 1 localhost:6000 localhost:5299")
     }
-
 }


### PR DESCRIPTION
Because of this bug, the `id` part of [CLUSTER NODES](https://redis.io/commands/cluster-nodes) response could be longer than 40 if the address of server proxy is too long. Need to limit it.