### PR TITLE
Remove warning for default compression config for replica proxy

### DIFF
--- a/src/proxy/compress.rs
+++ b/src/proxy/compress.rs
@@ -123,10 +123,7 @@ fn get_strategy(dbname: &str, meta_map: &SharedMetaMap) -> CompressionStrategy {
     let meta_map = meta_map.lease();
     match meta_map.get_db_map().get_config(&dbname) {
         Some(config) => config.compression_strategy,
-        None => {
-            warn!("failed to get config from {}. Use default config.", dbname);
-            ClusterConfig::default().compression_strategy
-        }
+        None => ClusterConfig::default().compression_strategy,
     }
 }
 

--- a/src/proxy/database.rs
+++ b/src/proxy/database.rs
@@ -5,12 +5,12 @@ use common::cluster::{SlotRange, SlotRangeTag};
 use common::config::ClusterConfig;
 use common::db::ProxyDBMeta;
 use common::utils::{gen_moved, get_key, get_slot};
+use crc64::crc64;
 use protocol::{Array, BulkStr, Resp};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::iter::Iterator;
-use crc64::crc64;
 
 pub const DEFAULT_DB: &str = "admin";
 


### PR DESCRIPTION
Replica server proxy will trigger this warning:
https://github.com/doyoubi/undermoon/issues/62

We can't move it inside `DatabaseMap` because later we may also need to forward the requests to local Redis.