### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,7 +2049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "undermoon"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["doyoubi"]
 
 [[bin]]

--- a/src/common/version.rs
+++ b/src/common/version.rs
@@ -1,2 +1,2 @@
-pub const UNDERMOON_VERSION: &str = "0.1.3";
+pub const UNDERMOON_VERSION: &str = "0.1.4";
 pub const UNDERMOON_MIGRATION_VERSION: &str = "mgr-0.1";


### PR DESCRIPTION
## Features
- Support EVAL command

## Pull Requests
- [Support eval command](https://github.com/doyoubi/undermoon/pull/66)
- [Remove warning for default compression config for replica proxy](https://github.com/doyoubi/undermoon/pull/64)
- [Use crc64 to hash address in CLUSTER NODES instead of pure address](https://github.com/doyoubi/undermoon/pull/63)
- [Add Dockerfile for release build](https://github.com/doyoubi/undermoon/pull/60)