### PR TITLE
Refactor SlotRange to store multiple slot ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ makes easier maintenance of both small and large, just a few and a great amount 
 
 ##### Why server-side proxy?
 A server-side proxy is able to migrate the data and scale in a super fast way
-by using the `Redis Replication Protocol`
-and make it possible to have a better control of full sync in replication.
+by using some customized migration protocols.
 
 ## Quick Tour Examples
 Requirements:
@@ -190,7 +189,7 @@ This is where the `Coordinator` comes in.
 Undermoon also provides a `Coordinator` to do something similar to the `checker.py` above in example (3).
 It will keep checking the server-side proxies and do failover.
 However, `Coordinator` itself does not store any data. It is a stateless service backed by a HTTP broker maintaining the meta data.
-You can implement this HTTP broker yourself and there's a [Golang implementation](https://github.com/doyoubi/overmoon).
+You can implement this HTTP broker yourself and there's a [Golang implementation](https://github.com/doyoubi/overmoon) working in progress.
 
 ![architecture](docs/architecture.svg)
 
@@ -276,26 +275,6 @@ Sets the replication metadata to server-side proxies. This API supports multiple
 Refer to [HTTP API documentation](./docs/broker_http_api.md).
 
 ## TODO
-- ~~Basic proxy implementation~~ (done)
-- ~~Multiple backend connections~~ (done)
-- ~~Slot map and cluster map~~ (done)
-- ~~Implement AUTH command to select database~~ (done)
-- ~~Implement meta data manipulation api~~ (done)
-- ~~Basic coordinator implementation~~ (done)
-- ~~Support slot migration via replication~~ (done)
-- ~~Optimize RESP parsing~~ (done)
-- ~~Implement CLUSTER SLOTS~~ (done)
-- ~~Implement commands to get proxy meta~~ (done)
-- ~~Track spawned futures~~ (done)
-- ~~Simple script to push configuration to proxy for demonstration~~ (done)
-- ~~Batch write operations with interval flushing~~ (done)
-- ~~Add configuration~~ (done)
 - Limit running commands, connections
-- ~~Slow log~~ (done)
 - Statistics
-- ~~Support multi-key commands~~ (done)
-- ~~Support dynamic configuration by CONFIG command~~ (done)
-- ~~Implement a simple rust HTTP broker before we have the Golang broker based on etcd.~~ (done)
 - Recover peer meta after reboot to support redirection.
-- ~~Syscall batching~~ (done)
-- ~~String Compression~~ (done)

--- a/README.md
+++ b/README.md
@@ -27,24 +27,13 @@ $ redis-server
 ```bash
 # Build and run the server_proxy
 > cargo build
-> target/debug/server_proxy  # runs on port 5299 and will forward commands to 127.0.0.1:6379
+> make server  # runs on port 5299 and will forward commands to 127.0.0.1:6379
 ```
 
-Note that how we use the `AUTH` command to do something like `USE [database]` in Mysql.
 ```bash
 > redis-cli -p 5299
 # Initialize the proxy by `UMCTL` commands.
-127.0.0.1:5299> UMCTL SETDB 1 NOFLAGS mydb 127.0.0.1:6379 0-8000 PEER mydb 127.0.0.1:7000 8001-16383
-
-# Now we still didn't select our database `mydb` we just set.
-# Then we are in the default `admin` database for our connection.
-# Since nothing was set for `admin` so we get a error.
-127.0.0.1:5299> get a
-(error) db not found: admin
-
-# Now choose to use our `mydb`.
-127.0.0.1:5299> AUTH mydb
-OK
+127.0.0.1:5299> UMCTL SETDB 1 NOFLAGS mydb 127.0.0.1:6379 1 0-8000 PEER mydb 127.0.0.1:7000 1 8001-16383
 
 # Done! We can use it like a Redis Cluster!
 127.0.0.1:5299> CLUSTER NODES
@@ -265,9 +254,10 @@ Sets the mapping relationship between the server-side proxy and its correspondin
 Every running server-side proxy will store its epoch and will reject all the `UMCTL [SETDB|SETREPL]` requests which don't have higher epoch.
 - `flags`: Currently it may be NOFLAG or FORCE. When it's `FORCE`, the server-side proxy will ignore the epoch rule above and will always accept the configuration
 - `slot_range` can be like
-    - 0-1000
-    - migrating 0-1000 epoch src_proxy_address src_node_address dst_proxy_address dst_node_address
-    - importing 0-1000 epoch src_proxy_address src_node_address dst_proxy_address dst_node_address
+    - 1 0-1000
+    - 2 0-1000 2000-3000
+    - migrating 1 0-1000 epoch src_proxy_address src_node_address dst_proxy_address dst_node_address
+    - importing 1 0-1000 epoch src_proxy_address src_node_address dst_proxy_address dst_node_address
 - `ip:port` should be the addresses of redis instances or other proxies for `PEER` part.
 
 Note that both these two commands set all the `local` or `peer` meta data of the proxy.

--- a/examples/failover/checker.py
+++ b/examples/failover/checker.py
@@ -78,14 +78,14 @@ def send_config(address, slots_config, nodes_config):
 
     setdb = ['UMCTL', 'SETDB', '1', 'FORCE']
     for start, end in slots_config[address]:
-        setdb.extend([DB_NAME, nodes_config[address], '{}-{}'.format(start, end)])
+        setdb.extend([DB_NAME, nodes_config[address], '1', '{}-{}'.format(start, end)])
 
     setdb.append('PEER')
     for node, slots in slots_config.items():
         if node == address:
             continue
         for start, end in slots:
-            setdb.extend([DB_NAME, node, '{}-{}'.format(start, end)])
+            setdb.extend([DB_NAME, node, '1', '{}-{}'.format(start, end)])
 
     logger.info('sending setdb: %s', setdb)
     client.execute_command(*setdb)

--- a/examples/multi-redis/init.sh
+++ b/examples/multi-redis/init.sh
@@ -18,4 +18,4 @@ until wait_redis server_proxy 5299; do
     sleep 1
 done
 
-redis-cli -h server_proxy -p 5299 UMCTL SETDB 1 FORCE mydb redis1:6379 0-5461 mydb redis2:6379 5462-10922 mydb redis3:6379 10923-16383
+redis-cli -h server_proxy -p 5299 UMCTL SETDB 1 FORCE mydb redis1:6379 1 0-5461 mydb redis2:6379 1 5462-10922 mydb redis3:6379 1 10923-16383

--- a/examples/multi-shard/init.sh
+++ b/examples/multi-shard/init.sh
@@ -24,6 +24,6 @@ for i in "${!proxy_list[@]}"; do
     done
 done
 
-redis-cli -h server_proxy1 -p 6001 UMCTL SETDB 1 FORCE mydb redis1:6379 0-5461 PEER mydb server_proxy2:6002 5462-10922 mydb server_proxy3:6003 10923-16383
-redis-cli -h server_proxy2 -p 6002 UMCTL SETDB 1 FORCE mydb redis2:6379 5462-10922 PEER mydb server_proxy1:6001 0-5461 mydb server_proxy3:6003 10923-16383
-redis-cli -h server_proxy3 -p 6003 UMCTL SETDB 1 FORCE mydb redis3:6379 10923-16383 PEER mydb server_proxy1:6001 0-5461 mydb server_proxy2:6002 5462-10922
+redis-cli -h server_proxy1 -p 6001 UMCTL SETDB 1 FORCE mydb redis1:6379 1 0-5461 PEER mydb server_proxy2:6002 1 5462-10922 mydb server_proxy3:6003 1 10923-16383
+redis-cli -h server_proxy2 -p 6002 UMCTL SETDB 1 FORCE mydb redis2:6379 1 5462-10922 PEER mydb server_proxy1:6001 1 0-5461 mydb server_proxy3:6003 1 10923-16383
+redis-cli -h server_proxy3 -p 6003 UMCTL SETDB 1 FORCE mydb redis3:6379 1 10923-16383 PEER mydb server_proxy1:6001 1 0-5461 mydb server_proxy2:6002 1 5462-10922

--- a/src/broker/service.rs
+++ b/src/broker/service.rs
@@ -162,10 +162,11 @@ impl MemBrokerService {
 
     pub fn get_failures(&self) -> Vec<String> {
         let failure_ttl = chrono::Duration::seconds(self.config.failure_ttl as i64);
+        let failure_quorum = self.config.failure_quorum;
         self.store
             .write()
             .expect("MemBrokerService::get_failures")
-            .get_failures(failure_ttl)
+            .get_failures(failure_ttl, failure_quorum)
     }
 
     pub fn add_failure(&self, address: String, reporter_id: String) {

--- a/src/broker/store.rs
+++ b/src/broker/store.rs
@@ -1,5 +1,6 @@
 use crate::common::cluster::{
-    Cluster, MigrationTaskMeta, Node, PeerProxy, Proxy, ReplMeta, ReplPeer, SlotRange, SlotRangeTag,
+    Cluster, MigrationTaskMeta, Node, PeerProxy, Proxy, Range, RangeList, ReplMeta, ReplPeer,
+    SlotRange, SlotRangeTag,
 };
 use crate::common::cluster::{DBName, Role};
 use crate::common::config::ClusterConfig;
@@ -323,8 +324,10 @@ impl MetaStore {
             let b = a + 1;
 
             let create_slots = |index| SlotRange {
-                start: index * range_per_node,
-                end: cmp::min((index + 1) * range_per_node - 1, SLOT_NUM - 1),
+                range_list: RangeList::from_single_range(Range(
+                    index * range_per_node,
+                    cmp::min((index + 1) * range_per_node - 1, SLOT_NUM - 1),
+                )),
                 tag: SlotRangeTag::None,
             };
 

--- a/src/common/cluster.rs
+++ b/src/common/cluster.rs
@@ -235,7 +235,7 @@ impl RangeList {
     pub fn get_slots_num(&self) -> usize {
         self.get_ranges()
             .iter()
-            .map(|range| range.end() - range.start())
+            .map(|range| range.end() - range.start() + 1)
             .sum()
     }
 }

--- a/src/common/cluster.rs
+++ b/src/common/cluster.rs
@@ -76,6 +76,20 @@ impl SlotRangeTag {
         }
     }
 
+    pub fn is_stable(&self) -> bool {
+        match self {
+            SlotRangeTag::None => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_migrating(&self) -> bool {
+        match self {
+            SlotRangeTag::Migrating(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_importing(&self) -> bool {
         match self {
             SlotRangeTag::Importing(_) => true,

--- a/src/common/cluster.rs
+++ b/src/common/cluster.rs
@@ -95,6 +95,14 @@ impl Range {
     pub fn end(&self) -> usize {
         self.1
     }
+
+    pub fn start_mut(&mut self) -> &mut usize {
+        &mut self.0
+    }
+
+    pub fn end_mut(&mut self) -> &mut usize {
+        &mut self.1
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -113,6 +121,10 @@ impl TryFrom<&str> for RangeList {
 }
 
 impl RangeList {
+    pub fn new(ranges: Vec<Range>) -> Self {
+        Self(ranges)
+    }
+
     pub fn from_single_range(mut range: Range) -> Self {
         if range.start() > range.end() {
             swap(&mut range.0, &mut range.1);
@@ -195,6 +207,17 @@ impl RangeList {
 
     pub fn get_ranges(&self) -> &[Range] {
         &self.0
+    }
+
+    pub fn get_mut_ranges(&mut self) -> &mut Vec<Range> {
+        &mut self.0
+    }
+
+    pub fn get_slots_num(&self) -> usize {
+        self.get_ranges()
+            .iter()
+            .map(|range| range.end() - range.start())
+            .sum()
     }
 }
 
@@ -331,6 +354,10 @@ impl SlotRange {
 
     pub fn get_range_list(&self) -> &RangeList {
         &self.range_list
+    }
+
+    pub fn get_mut_range_list(&mut self) -> &mut RangeList {
+        &mut self.range_list
     }
 
     pub fn to_range_list(&self) -> RangeList {

--- a/src/common/cluster.rs
+++ b/src/common/cluster.rs
@@ -142,6 +142,11 @@ impl RangeList {
         range_list
     }
 
+    pub fn merge_another(&mut self, range_list: &mut RangeList) {
+        self.0.append(&mut range_list.0);
+        self.compact();
+    }
+
     fn parse<It>(it: &mut It) -> Option<Self>
     where
         It: Iterator<Item = String>,

--- a/src/common/cluster.rs
+++ b/src/common/cluster.rs
@@ -390,6 +390,7 @@ impl DBName {
         Self(DBNameInner::new())
     }
 
+    // TODO: use TryFrom
     pub fn from(s: &str) -> Result<Self, InvalidDBName> {
         Ok(Self(DBNameInner::from(s).map_err(|_| InvalidDBName)?))
     }

--- a/src/coordinator/detector.rs
+++ b/src/coordinator/detector.rs
@@ -264,13 +264,14 @@ mod tests {
     use super::super::core::{FailureDetector, ParFailureDetector};
     use super::*;
     use crate::common::cluster::{
-        DBName, MigrationMeta, Node, ReplMeta, Role, SlotRange, SlotRangeTag,
+        DBName, MigrationMeta, Node, RangeList, ReplMeta, Role, SlotRange, SlotRangeTag,
     };
     use crate::common::config::ClusterConfig;
     use crate::protocol::{
         Array, BinSafeStr, OptionalMulti, RedisClient, RedisClientError, Resp, RespVec,
     };
     use futures::{future, stream, StreamExt};
+    use std::convert::TryFrom;
     use std::pin::Pin;
     use std::sync::Arc;
     use tokio;
@@ -371,8 +372,7 @@ mod tests {
                 "host1:port1".to_string(),
                 DBName::from("dybdb").unwrap(),
                 vec![SlotRange {
-                    start: 0,
-                    end: 233,
+                    range_list: RangeList::try_from("1 0-233").unwrap(),
                     tag: SlotRangeTag::Migrating(mgr_meta.clone()),
                 }],
                 ReplMeta::new(Role::Master, Vec::new()),
@@ -382,8 +382,7 @@ mod tests {
                 "host2:port2".to_string(),
                 DBName::from("dybdb").unwrap(),
                 vec![SlotRange {
-                    start: 666,
-                    end: 6699,
+                    range_list: RangeList::try_from("1 666-6699").unwrap(),
                     tag: SlotRangeTag::None,
                 }],
                 ReplMeta::new(Role::Master, Vec::new()),
@@ -393,8 +392,7 @@ mod tests {
                 "host3:port3".to_string(),
                 DBName::from("dybdb").unwrap(),
                 vec![SlotRange {
-                    start: 0,
-                    end: 233,
+                    range_list: RangeList::try_from("1 0-233").unwrap(),
                     tag: SlotRangeTag::Importing(mgr_meta),
                 }],
                 ReplMeta::new(Role::Master, Vec::new()),

--- a/src/coordinator/sync.rs
+++ b/src/coordinator/sync.rs
@@ -119,7 +119,7 @@ fn generate_host_meta_cmd_args(flags: DBMapFlags, proxy: Proxy) -> Vec<String> {
     proxy_db_meta.to_args()
 }
 
-// sub_command should be SETDB
+// sub_command should be SETDB, SETREPL
 async fn send_meta<C: RedisClient>(
     client: &mut C,
     sub_command: String,
@@ -224,10 +224,11 @@ mod tests {
     use super::super::core::{ProxyMetaRespSynchronizer, ProxyMetaSynchronizer};
     use super::super::detector::BrokerProxiesRetriever;
     use super::*;
-    use crate::common::cluster::{Node, ReplMeta, ReplPeer, SlotRange, SlotRangeTag};
+    use crate::common::cluster::{Node, RangeList, ReplMeta, ReplPeer, SlotRange, SlotRangeTag};
     use crate::common::config::ClusterConfig;
     use crate::protocol::{BinSafeStr, DummyRedisClientFactory, MockRedisClient, Resp};
     use futures::{stream, StreamExt};
+    use std::convert::TryFrom;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use tokio;
@@ -235,8 +236,7 @@ mod tests {
     fn gen_testing_proxy(role: Role) -> Proxy {
         let dbname = DBName::from("mydb").unwrap();
         let slot_range = SlotRange {
-            start: 233,
-            end: 666,
+            range_list: RangeList::try_from("1 233-666").unwrap(),
             tag: SlotRangeTag::None,
         };
         let repl = ReplMeta::new(
@@ -298,7 +298,7 @@ mod tests {
     }
 
     fn gen_set_db_args() -> Vec<String> {
-        vec!["7799", "NOFLAG", "mydb", "127.0.0.1:7001", "233-666"]
+        vec!["7799", "NOFLAG", "mydb", "127.0.0.1:7001", "1", "233-666"]
             .into_iter()
             .map(|s| s.to_string())
             .collect()

--- a/src/migration/delete_keys.rs
+++ b/src/migration/delete_keys.rs
@@ -1,5 +1,5 @@
 use super::task::{ScanResponse, SlotRangeArray};
-use crate::common::cluster::{DBName, SlotRange};
+use crate::common::cluster::{DBName, RangeList, SlotRange};
 use crate::common::config::AtomicMigrationConfig;
 use crate::common::db::ProxyDBMap;
 use crate::common::future_group::{new_auto_drop_future, FutureAutoStopHandle};
@@ -117,11 +117,10 @@ impl DeleteKeysTask {
     ) -> Self {
         let slot_ranges = slot_ranges
             .into_iter()
-            .map(|range| (range.start, range.end))
+            .map(|range| range.to_range_list())
             .collect();
-        let slot_ranges = SlotRangeArray {
-            ranges: slot_ranges,
-        };
+        let range_list = RangeList::merge(slot_ranges);
+        let slot_ranges = SlotRangeArray::new(range_list);
         let finished = Arc::new(AtomicBool::new(false));
         let (fut, handle) = Self::gen_future(
             address.clone(),

--- a/src/migration/scan_migration.rs
+++ b/src/migration/scan_migration.rs
@@ -1,4 +1,5 @@
 use super::task::{ScanResponse, SlotRangeArray};
+use crate::common::cluster::SlotRange;
 use crate::common::config::AtomicMigrationConfig;
 use crate::common::future_group::{new_auto_drop_future, FutureAutoStopHandle};
 use crate::common::resp_execution::{
@@ -69,13 +70,12 @@ impl ScanMigrationTask {
     pub fn new<F: RedisClientFactory>(
         src_address: String,
         dst_address: String,
-        slot_range: (usize, usize),
+        slot_range: SlotRange,
         client_factory: Arc<F>,
         config: Arc<AtomicMigrationConfig>,
     ) -> Self {
-        let slot_ranges = SlotRangeArray {
-            ranges: vec![slot_range],
-        };
+        let ranges = slot_range.to_range_list();
+        let slot_ranges = SlotRangeArray::new(ranges);
         let (data_sender, data_receiver) = mpsc::channel(DATA_QUEUE_SIZE);
         let (stop_sender, stop_receiver) = oneshot::channel();
         let counter = Arc::new(AtomicI64::new(0));

--- a/src/proxy/slot.rs
+++ b/src/proxy/slot.rs
@@ -11,8 +11,10 @@ impl SlotMap {
         let mut map = HashMap::new();
         for (addr, slot_ranges) in slot_map {
             let mut slots = Vec::new();
-            for range in slot_ranges {
-                slots.push((range.start, range.end));
+            for slot_range in slot_ranges {
+                for range in slot_range.get_range_list().get_ranges() {
+                    slots.push((range.start(), range.end()));
+                }
             }
             map.insert(addr, slots);
         }
@@ -72,7 +74,8 @@ impl SlotMapData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::cluster::{SlotRange, SlotRangeTag};
+    use crate::common::cluster::{RangeList, SlotRange, SlotRangeTag};
+    use std::convert::TryFrom;
 
     #[test]
     fn test_slot_map() {
@@ -81,8 +84,7 @@ mod tests {
         range_map.insert(
             backend.clone(),
             vec![SlotRange {
-                start: 0,
-                end: SLOT_NUM - 1,
+                range_list: RangeList::try_from(format!("1 0-{}", SLOT_NUM - 1).as_str()).unwrap(),
                 tag: SlotRangeTag::None,
             }],
         );


### PR DESCRIPTION
Let `SlotRange` store multiple slots ranges like `0-10 40-90 ...`.
We need this for the following reasons:
- After scaling up and down multiple times, the slot ranges of a cluster could become scattered and result in some performance problems in both the broker API and server proxy API.
- Help support migrating multiple slots ranges at the same time.

This will change the HTTP broker API so after this PR, the `overmoon` 0.1 will not work with server proxy anymore.

Later I will stabilize the `mem_broker` first before moving `overmoon` to support this new broker API.