### PR TITLE
Change not to synchronize the metadata for free but failed server proxy

### DIFF
--- a/docs/broker_http_api.md
+++ b/docs/broker_http_api.md
@@ -128,6 +128,7 @@ empty payload
 
 Response:
 If success:
+Proxy is being used by a cluster.
 {
     "proxy": {
         "address": "server_proxy_address1",
@@ -150,6 +151,12 @@ If success:
         }, ...]
     }
 }
+
+Proxy is not in use:
+{
+    "proxy": null
+}
+
 If not:
 HTTP 409
 ```

--- a/docs/broker_http_api.md
+++ b/docs/broker_http_api.md
@@ -111,7 +111,8 @@ empty payload
 ```
 
 ##### (6) GET /api/v2/failures
-Get all the failures.
+Get all the failures reported by coordinator but not committed to be failed yet.
+It's used by coordinator and you probably need to use (9) instead.
 ```
 Response:
 {
@@ -173,6 +174,15 @@ Request:
     }
 }
 
+Response:
+{
+    "addresses": ["server_proxy_address1", ...],
+}
+```
+
+##### (9) GET /api/v2/proxies/failed/addresses
+Get all the failed proxies.
+```
 Response:
 {
     "addresses": ["server_proxy_address1", ...],

--- a/src/bin/server_proxy.rs
+++ b/src/bin/server_proxy.rs
@@ -41,10 +41,10 @@ fn gen_conf() -> Result<ServerProxyConfig, &'static str> {
 
     let slowlog_len = NonZeroUsize::new(s.get::<usize>("slowlog_len").unwrap_or_else(|_| 1024))
         .ok_or_else(|| "slowlog_len")?;
-    let thread_number = NonZeroUsize::new(s.get::<usize>("thread_number").unwrap_or_else(|_| 4))
+    let thread_number = NonZeroUsize::new(s.get::<usize>("thread_number").unwrap_or_else(|_| 2))
         .ok_or_else(|| "thread_number")?;
     let backend_conn_num =
-        NonZeroUsize::new(s.get::<usize>("backend_conn_num").unwrap_or_else(|_| 16))
+        NonZeroUsize::new(s.get::<usize>("backend_conn_num").unwrap_or_else(|_| 2))
             .ok_or_else(|| "backend_conn_num")?;
     let backend_batch_buf =
         NonZeroUsize::new(s.get::<usize>("backend_batch_buf").unwrap_or_else(|_| 10))

--- a/src/broker/service.rs
+++ b/src/broker/service.rs
@@ -2,7 +2,8 @@ use super::store::{MetaStore, MetaStoreError, CHUNK_HALF_NODE_NUM};
 use crate::common::cluster::{Cluster, ClusterName, MigrationTaskMeta, Node, Proxy};
 use crate::common::version::UNDERMOON_VERSION;
 use crate::coordinator::http_meta_broker::{
-    ClusterNamesPayload, ClusterPayload, FailuresPayload, ProxyAddressesPayload, ProxyPayload,
+    ClusterNamesPayload, ClusterPayload, FailedProxiesPayload, FailuresPayload,
+    ProxyAddressesPayload, ProxyPayload,
 };
 use actix_http::ResponseBuilder;
 use actix_web::dev::Service;
@@ -59,6 +60,7 @@ pub fn configure_app(cfg: &mut web::ServiceConfig, service: Arc<MemBrokerService
                 web::post().to(replace_failed_node),
             )
             .route("/clusters/migrations", web::put().to(commit_migration))
+            .route("/proxies/failed/addresses", web::get().to(get_failed_proxies))
 
             // Additional api
             .route("/clusters/meta/{cluster_name}", web::post().to(add_cluster))
@@ -251,6 +253,13 @@ impl MemBrokerService {
             .expect("MemBrokerService::replace_failed_node")
             .replace_failed_proxy(failed_proxy_address, migration_limit)
     }
+
+    pub fn get_failed_proxies(&self) -> Vec<String> {
+        self.store
+            .read()
+            .expect("MemBrokerService::get_failed_proxies")
+            .get_failed_proxies()
+    }
 }
 
 type ServiceState = web::Data<Arc<MemBrokerService>>;
@@ -407,6 +416,11 @@ async fn replace_failed_node(
 ) -> Result<web::Json<Proxy>, MetaStoreError> {
     let (proxy_address,) = path.into_inner();
     state.replace_failed_node(proxy_address).map(web::Json)
+}
+
+async fn get_failed_proxies(state: ServiceState) -> impl Responder {
+    let addresses = state.get_failed_proxies();
+    web::Json(FailedProxiesPayload { addresses })
 }
 
 impl error::ResponseError for MetaStoreError {

--- a/src/broker/store.rs
+++ b/src/broker/store.rs
@@ -1565,6 +1565,10 @@ impl MetaStore {
 
         Ok(())
     }
+
+    pub fn get_failed_proxies(&self) -> Vec<String> {
+        self.failed_proxies.iter().cloned().collect()
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/coordinator/broker.rs
+++ b/src/coordinator/broker.rs
@@ -55,7 +55,11 @@ mod trait_mod {
         fn replace_proxy<'s>(
             &'s self,
             failed_proxy_address: String,
-        ) -> Pin<Box<dyn Future<Output = Result<Proxy, MetaManipulationBrokerError>> + Send + 's>>;
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<Option<Proxy>, MetaManipulationBrokerError>> + Send + 's,
+            >,
+        >;
 
         fn commit_migration<'s>(
             &'s self,

--- a/src/coordinator/broker.rs
+++ b/src/coordinator/broker.rs
@@ -42,6 +42,10 @@ mod trait_mod {
         fn get_failures<'s>(
             &'s self,
         ) -> Pin<Box<dyn Stream<Item = Result<String, MetaDataBrokerError>> + Send + 's>>;
+
+        fn get_failed_proxies<'s>(
+            &'s self,
+        ) -> Pin<Box<dyn Stream<Item = Result<String, MetaDataBrokerError>> + Send + 's>>;
     }
 
     // Maybe we would want to support other database supporting redis protocol.

--- a/src/coordinator/migration.rs
+++ b/src/coordinator/migration.rs
@@ -247,6 +247,9 @@ mod tests {
                 Box::pin(stream::iter(results))
             });
         mock_data_broker
+            .expect_get_failed_proxies()
+            .returning(|| Box::pin(stream::iter(vec![])));
+        mock_data_broker
             .expect_get_proxy()
             .withf(|proxy_addr| proxy_addr == "127.0.0.1:6000")
             .returning(|_| Box::pin(async { Ok(Some(gen_testing_dummy_proxy("127.0.0.1:6000"))) }));

--- a/src/coordinator/recover.rs
+++ b/src/coordinator/recover.rs
@@ -104,7 +104,7 @@ mod tests {
             .expect_replace_proxy()
             .withf(move |f| f == failure2)
             .times(1)
-            .returning(move |_| Box::pin(async { Ok(gen_testing_dummy_proxy()) }));
+            .returning(move |_| Box::pin(async { Ok(Some(gen_testing_dummy_proxy())) }));
         let mock_broker = Arc::new(mock_broker);
 
         let handler = ReplaceNodeHandler::new(mock_broker);
@@ -128,7 +128,7 @@ mod tests {
             .expect_replace_proxy()
             .withf(move |f| f == failure2)
             .times(1)
-            .returning(move |_| Box::pin(async { Ok(gen_testing_dummy_proxy()) }));
+            .returning(move |_| Box::pin(async { Ok(Some(gen_testing_dummy_proxy())) }));
         let mock_mani_broker = Arc::new(mock_mani_broker);
 
         let retriever = BrokerProxyFailureRetriever::new(mock_data_broker);

--- a/src/coordinator/sync.rs
+++ b/src/coordinator/sync.rs
@@ -435,6 +435,9 @@ mod tests {
             Box::pin(stream::iter(results))
         });
         mock_broker
+            .expect_get_failed_proxies()
+            .returning(|| Box::pin(stream::iter(vec![])));
+        mock_broker
             .expect_get_proxy()
             .withf(move |addr| addr == &proxy_addr)
             .times(1)


### PR DESCRIPTION
- Add `/proxies/failed/addresses` for the broker to ignore failed proxies when synchronizing metadata.
- Fix replicator exiting after `set_meta` caused by dropping handles.
- Fix migration after failure recovery.
- Let `/api/v2/proxies/failover/<server_proxy_address>` return Option<Proxy>.