### PR TITLE
Bump version to 0.3.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "undermoon"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = ["doyoubi"]
 edition = "2018"
 

--- a/src/common/version.rs
+++ b/src/common/version.rs
@@ -1,3 +1,3 @@
-pub const UNDERMOON_VERSION: &str = "0.3.0-alpha.1";
+pub const UNDERMOON_VERSION: &str = "0.3.0-alpha.2";
 pub const UNDERMOON_MIGRATION_VERSION: &str = "mgr-0.2";
 pub const UNDERMOON_MEM_BROKER_META_VERSION: &str = "mem-broker-0.1";


### PR DESCRIPTION
- More API for `memory broker`
- Replication and Persistence for `memory broker`
- Support non-cluster-mode clients
- Performance Optimization
- Support `CLUSTER KEYSLOT`
- More tests
- Better docs
- Bug fixes