### PR TITLE
Work around bug in pooled redis client

### DIFF
--- a/chaostest/random_test.py
+++ b/chaostest/random_test.py
@@ -209,10 +209,24 @@ class RandomTester:
 
             if names and random.randint(0, 300) < 1:
                 cluster_name = random.choice(names)
-                self.overmoon_client.delete_cluster(cluster_name)
-                self.kvs_tester.pop(cluster_name, None)
+                if not self.check_migration_running(cluster_name):
+                    self.overmoon_client.delete_cluster(cluster_name)
+                    self.kvs_tester.pop(cluster_name, None)
 
             time.sleep(0.1)
+
+    def check_migration_running(self, cluster_name):
+        cluster = self.overmoon_client.get_cluster(cluster_name)
+        if cluster is None:
+            return False
+        nodes = cluster['nodes']
+        for node in nodes:
+            slots = node['slots']
+            for slot_range in slots:
+                tag = slot_range['tag']
+                if tag != "None":
+                    return True
+        return False
 
     def keep_testing(self):
         while not self.stopped:

--- a/src/bin/server_proxy.rs
+++ b/src/bin/server_proxy.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use string_error::into_err;
 use undermoon::common::track::TrackedFutureRegistry;
-use undermoon::protocol::PooledRedisClientFactory;
+use undermoon::protocol::SimpleRedisClientFactory;
 use undermoon::proxy::backend::DefaultConnFactory;
 use undermoon::proxy::executor::SharedForwardHandler;
 use undermoon::proxy::manager::MetaMap;
@@ -117,8 +117,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let config = Arc::new(conf);
 
     let timeout = Duration::new(1, 0);
-    let pool_size = 4;
-    let client_factory = PooledRedisClientFactory::new(pool_size, timeout);
+    let client_factory = SimpleRedisClientFactory::new(timeout);
 
     let slow_request_logger = Arc::new(SlowRequestLogger::new(config.clone()));
     let meta_map = Arc::new(ArcSwap::new(Arc::new(MetaMap::empty())));

--- a/src/common/resp_execution.rs
+++ b/src/common/resp_execution.rs
@@ -37,6 +37,7 @@ where
                 }
             }
         };
+
         match keep_sending_cmd(
             &mut c,
             opt_multi_cmd.clone(),

--- a/src/common/response.rs
+++ b/src/common/response.rs
@@ -2,6 +2,7 @@ pub const OK_REPLY: &str = "OK";
 pub const OLD_EPOCH_REPLY: &str = "OLD_EPOCH";
 pub const TRY_AGAIN_REPLY: &str = "TRY_AGAIN";
 pub const NOT_READY_FOR_SWITCHING_REPLY: &str = "NOT_READY_FOR_SWITCHING";
+pub const TASK_NOT_FOUND: &str = "TASK_NOT_FOUND";
 pub const ERR_NOT_THE_SAME_SLOT: &str = "ERR_MULTI_SLOTS slots of the keys are not the same";
 pub const ERR_CLUSTER_NOT_FOUND: &str = "ERR_CLUSTER_NOT_FOUND";
 pub const ERR_BACKEND_CONNECTION: &str = "ERR_BACKEND_CONNECTION";

--- a/src/coordinator/detector.rs
+++ b/src/coordinator/detector.rs
@@ -220,7 +220,10 @@ impl<F: RedisClientFactory> PingFailureDetector<F> {
         let mut client = match self.client_factory.create_client(address.clone()).await {
             Ok(client) => client,
             Err(err) => {
-                error!("PingFailureDetector::check failed to connect: {:?}", err);
+                error!(
+                    "PingFailureDetector::check failed to connect: {} {:?}",
+                    address, err
+                );
                 return Ok(Some(address));
             }
         };
@@ -231,7 +234,10 @@ impl<F: RedisClientFactory> PingFailureDetector<F> {
         match client.execute_single(ping_command).await {
             Ok(_) => Ok(None),
             Err(err) => {
-                error!("PingFailureDetector::check failed to send PING: {:?}", err);
+                error!(
+                    "PingFailureDetector::check failed to send PING: {} {:?}",
+                    address, err
+                );
                 Err(CoordinateError::Redis(err))
             }
         }

--- a/src/migration/delete_keys.rs
+++ b/src/migration/delete_keys.rs
@@ -217,7 +217,10 @@ impl DeleteKeysTask {
 
         let resp = client.execute_single(byte_cmd).await?;
         let ScanResponse { next_index, keys } =
-            ScanResponse::parse_scan(resp).ok_or_else(|| RedisClientError::InvalidReply)?;
+            ScanResponse::parse_scan(&resp).ok_or_else(|| {
+                error!("Invalid scan reply for deleting keys: {:?}", resp);
+                RedisClientError::InvalidReply
+            })?;
 
         let keys: Vec<Vec<u8>> = keys
             .into_iter()

--- a/src/migration/scan_migration.rs
+++ b/src/migration/scan_migration.rs
@@ -294,7 +294,10 @@ impl ScanMigrationTask {
 
         let resp = client.execute_single(byte_cmd).await?;
         let ScanResponse { next_index, keys } =
-            ScanResponse::parse_scan(resp).ok_or_else(|| RedisClientError::InvalidReply)?;
+            ScanResponse::parse_scan(&resp).ok_or_else(|| {
+                error!("Invalid scan reply: {:?}", resp);
+                RedisClientError::InvalidReply
+            })?;
 
         let (slot_ranges, entries) = Self::produce_entries(slot_ranges, keys, client).await?;
 

--- a/src/migration/task.rs
+++ b/src/migration/task.rs
@@ -228,7 +228,7 @@ pub struct ScanResponse {
 }
 
 impl ScanResponse {
-    pub fn parse_scan(resp: RespVec) -> Option<ScanResponse> {
+    pub fn parse_scan(resp: &RespVec) -> Option<ScanResponse> {
         match resp {
             Resp::Arr(Array::Arr(ref resps)) => {
                 let index_data = resps.get(0).and_then(|resp| match resp {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -9,7 +9,7 @@ mod stateless;
 
 pub use self::client::{
     DummyRedisClientFactory, MockRedisClient, PooledRedisClient, PooledRedisClientFactory,
-    RedisClient, RedisClientError, RedisClientFactory,
+    RedisClient, RedisClientError, RedisClientFactory, SimpleRedisClient, SimpleRedisClientFactory,
 };
 pub use self::codec::RespCodec;
 pub use self::decoder::DecodeError;

--- a/src/proxy/executor.rs
+++ b/src/proxy/executor.rs
@@ -353,7 +353,7 @@ where
             Err(err) => {
                 let err_str = match err {
                     SwitchError::InvalidArg => "Invalid Arg".to_string(),
-                    SwitchError::TaskNotFound => "No Corresponding Task Found".to_string(),
+                    SwitchError::TaskNotFound => response::TASK_NOT_FOUND.to_string(),
                     SwitchError::PeerMigrating => "Peer Not Migrating".to_string(),
                     SwitchError::NotReady => response::NOT_READY_FOR_SWITCHING_REPLY.to_string(),
                     SwitchError::MgrErr(err) => format!("switch failed: {:?}", err),

--- a/src/proxy/manager.rs
+++ b/src/proxy/manager.rs
@@ -240,7 +240,7 @@ impl<F: RedisClientFactory, C: ConnFactory<Pkt = RespPacket>> MetaManager<F, C> 
         };
 
         if run_new_migration_task_while_deleting_key {
-            error!("New migration starts while deleting keys is still running for the last task. May lose some keys.");
+            error!("New migration starts while deleting keys is still running for the last task. Some keys may get old values.");
         }
         Ok(())
     }

--- a/src/replication/redis_replicator.rs
+++ b/src/replication/redis_replicator.rs
@@ -83,8 +83,11 @@ impl<F: RedisClientFactory> RedisReplicaReplicator<F> {
         let cmd = match Self::gen_cmd(&meta) {
             Ok(cmd) => cmd,
             Err(err) => {
-                error!("FATAL ERROR: invalid meta {:?}, keep going with just PING. Migration will get stuck.", err);
-                vec!["PING".to_string()]
+                error!(
+                    "FATAL ERROR: invalid meta {:?}, will see it as master.",
+                    err
+                );
+                vec!["SLAVEOF".to_string(), "NO".to_string(), "ONE".to_string()]
             }
         };
         let address = meta.replica_node_address.clone();


### PR DESCRIPTION
The pooled Redis client could result in getting the reply of the last request in server proxy. I still have no idea why. But replacing the pooled Redis client with a non-pooled one could fix the problem.
This will not have any performance impact on server proxy because the server proxy has already used some caching strategy.