### PR TITLE
Bump version to 0.3.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "undermoon"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 dependencies = [
  "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 authors = ["doyoubi"]
 edition = "2018"
 

--- a/src/common/version.rs
+++ b/src/common/version.rs
@@ -1,3 +1,3 @@
-pub const UNDERMOON_VERSION: &str = "0.3.0-alpha.2";
+pub const UNDERMOON_VERSION: &str = "0.3.0-alpha.3";
 pub const UNDERMOON_MIGRATION_VERSION: &str = "mgr-0.2";
 pub const UNDERMOON_MEM_BROKER_META_VERSION: &str = "mem-broker-0.1";


### PR DESCRIPTION
This alpha version includes several bug fixes and the scaling down functionality.
Pull Requests:
- [Fix invalid metadata in broker](https://github.com/doyoubi/undermoon/pull/161)
- [Add resource check for failures](https://github.com/doyoubi/undermoon/pull/160)
- [Check Del Task](https://github.com/doyoubi/undermoon/pull/158)
- [Add pre-check for client factory](https://github.com/doyoubi/undermoon/pull/157)
- [Refactor MetaStore](https://github.com/doyoubi/undermoon/pull/156)
- [Fix getting old response for pooled redis client](https://github.com/doyoubi/undermoon/pull/155)
- [Work around bug in pooled redis client](https://github.com/doyoubi/undermoon/pull/154)
- [Support scaling down](https://github.com/doyoubi/undermoon/pull/152)
- [Optimize setting cluster name](https://github.com/doyoubi/undermoon/pull/150)