### PR TITLE
Fix k8s mode

### DIFF
--- a/chaostest/USAGE.md
+++ b/chaostest/USAGE.md
@@ -11,6 +11,7 @@ pip install -r chaostest/requirements.txt
 ```
 
 #### (2) Generate docker-compose.yaml
+**Note that overmoon is not available yet.**
 ```
 python chaostest/render_compose.py [mem_broker|overmoon] [enable_failure]
 ```
@@ -25,7 +26,7 @@ make build-docker
 
 Build `undermoon`:
 ```
-docker-build-image
+make docker-build-image
 ```
 
 Or rebuild if the source codes are changed:

--- a/src/broker/service.rs
+++ b/src/broker/service.rs
@@ -411,10 +411,11 @@ impl MemBrokerService {
     }
 
     pub fn commit_migration(&self, task: MigrationTaskMeta) -> Result<(), MetaStoreError> {
+        // TODO: Maybe we need to make `clear_free_nodes` of `commit_migration` configurable.
         self.store
             .write()
             .expect("MemBrokerService::commit_migration")
-            .commit_migration(task, true)
+            .commit_migration(task, false)
     }
 
     pub fn replace_failed_proxy(

--- a/src/broker/update.rs
+++ b/src/broker/update.rs
@@ -867,15 +867,15 @@ impl<'a> MetaStoreUpdate<'a> {
 
         self.takeover_master(&cluster_name, failed_proxy_address.clone())?;
 
-        self.store
-            .failed_proxies
-            .insert(failed_proxy_address.clone());
-
         // If enable_ordered_proxy is true, we won't replace the proxy.
         if self.store.enable_ordered_proxy {
             self.store.bump_global_epoch();
             return Ok(None);
         }
+
+        self.store
+            .failed_proxies
+            .insert(failed_proxy_address.clone());
 
         let proxy_resource = self.generate_new_free_proxy(failed_proxy_address.clone())?;
         let new_epoch = self.store.bump_global_epoch();


### PR DESCRIPTION
- Not to move failed proxies to failed list in broker when `enable_ordered_proxy` is on.
- Not to remove free nodes from the cluster automatically after scaling down.