### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "undermoon"
-version = "0.3.1-alpha.0"
+version = "0.3.1"
 dependencies = [
  "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.3.1-alpha.0"
+version = "0.3.1"
 authors = ["doyoubi"]
 edition = "2018"
 

--- a/src/common/version.rs
+++ b/src/common/version.rs
@@ -1,3 +1,3 @@
-pub const UNDERMOON_VERSION: &str = "0.3.1-alpha.0";
+pub const UNDERMOON_VERSION: &str = "0.3.1";
 pub const UNDERMOON_MIGRATION_VERSION: &str = "mgr-0.2";
 pub const UNDERMOON_MEM_BROKER_META_VERSION: &str = "mem-broker-0.2";


### PR DESCRIPTION
This version starts to support kubernetes with [undermoon-operator](https://github.com/doyoubi/undermoon-operator) and fixes a data loss bug.

## Broker Data Format Change
To upgrade the memory broker from `0.3.0` to `0.3.1`,
we need to use the script 
```
> python scripts/mem_store_v1_to_v2.py metadata new_metadata
```
to migrate the memory broker data.

## Bug fixes compared to `0.3.0`:

- Temporarily losing keys during migration:
[Fix temporarily losing keys during migration if there's no many keys to migrate](https://github.com/doyoubi/undermoon/pull/201)

- May lose all the data of the same chunk after failover:
[Fix incorrect slots position after failover](https://github.com/doyoubi/undermoon/pull/203)
This could be fixed by balancing the masters back to the normal status.

## Features:
[Add config api for memory broker](https://github.com/doyoubi/undermoon/pull/184)
[Add apis to query epoch and broker config](https://github.com/doyoubi/undermoon/pull/187)
[Add auto scaling api](https://github.com/doyoubi/undermoon/pull/188/files)
[Support Kubernetes StatefulSet for memory broker](https://github.com/doyoubi/undermoon/pull/189)
[Fix Kubernetes mode](https://github.com/doyoubi/undermoon/pull/191)
[Support `UMCTL READY` for Kubernetes readiness](https://github.com/doyoubi/undermoon/pull/192)
[Add default_redirection_address for scaling down](https://github.com/doyoubi/undermoon/pull/194)
[Support inner retry for the server proxy](https://github.com/doyoubi/undermoon/pull/195/files)
[Remove recursive call in blocking module](https://github.com/doyoubi/undermoon/pull/196)
[Amend proxy readiness status](https://github.com/doyoubi/undermoon/pull/197)
[Use other crc16 hash function for key lock in migration](https://github.com/doyoubi/undermoon/pull/198)
[Fix ready status](https://github.com/doyoubi/undermoon/pull/200)
[Fix INVALID_NODE_NUMBER](https://github.com/doyoubi/undermoon/pull/202)

## Docs:
[Add development guide](https://github.com/doyoubi/undermoon/pull/181)
[Add docs on broker config api](https://github.com/doyoubi/undermoon/pull/186)
[Add docs on operator. Add script to migrate v1 broker data](https://github.com/doyoubi/undermoon/pull/205)

## Others:
[Support downloading undermoon image in the readme example](https://github.com/doyoubi/undermoon/pull/182)
[Rename overmoon to broker in chaostest](https://github.com/doyoubi/undermoon/pull/199)
