### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "undermoon"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["doyoubi"]
 edition = "2018"
 

--- a/src/common/version.rs
+++ b/src/common/version.rs
@@ -1,3 +1,3 @@
-pub const UNDERMOON_VERSION: &str = "0.3.1";
+pub const UNDERMOON_VERSION: &str = "0.3.2";
 pub const UNDERMOON_MIGRATION_VERSION: &str = "mgr-0.2";
 pub const UNDERMOON_MEM_BROKER_META_VERSION: &str = "mem-broker-0.2";


### PR DESCRIPTION
This version is a minor upgrade.

# Features
- [Upgrade the format of CLUSTER SLOTS to support redis-benchmark --cluster](https://github.com/doyoubi/undermoon/pull/214)
- [Change to use jemalloc](https://github.com/doyoubi/undermoon/pull/212)

# Others
- [Fix unexpected drop for multi-key command](https://github.com/doyoubi/undermoon/pull/213)
- [Change DNS resolving to async](https://github.com/doyoubi/undermoon/pull/210)
- [Set TCP_NODELAY for backend ](https://github.com/doyoubi/undermoon/pull/209)