### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,7 +2090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "undermoon"
-version = "0.4.0-alpha.4"
+version = "0.4.0"
 dependencies = [
  "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.4.0-alpha.4"
+version = "0.4.0"
 authors = ["doyoubi"]
 edition = "2018"
 


### PR DESCRIPTION
# Release 0.4.0
This release supports external storage for **memory broker** so that the [undermoon-operator](https://github.com/doyoubi/undermoon-operator) can use ConfigMap in Kubernetes to store metadata.

From this version, the `announce_address` of a server proxy should be the same address registered in the memory broker and all the Redis addresses in broker under this server proxy have the same host as `announce_address`

## External Storage Feature
[Fix sending meta to wrong node in kubernetes](https://github.com/doyoubi/undermoon/pull/231)
[Reduce unnecessary conflict for external storage](https://github.com/doyoubi/undermoon/pull/228)
[Optimize add failure api for external storage](https://github.com/doyoubi/undermoon/pull/226)
[Optimize add proxy api](https://github.com/doyoubi/undermoon/pull/223)
[Broker timeout err](https://github.com/doyoubi/undermoon/pull/222)
[Add undermoon_name and password](https://github.com/doyoubi/undermoon/pull/220)
[Broker external storage](https://github.com/doyoubi/undermoon/pull/219)

## Bugs
This only affects clusters in Kubernetes.
[Fix replication domain resolution](https://github.com/doyoubi/undermoon/pull/225)