### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "undermoon"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["doyoubi"]
 edition = "2018"
 


### PR DESCRIPTION
# Release v0.4.4
This version fixes that broker may be unable to initialize metadata in [undermoon-operator](https://github.com/doyoubi/undermoon-operator).

## Pull Requests
- [Add retry for initializing broker data](https://github.com/doyoubi/undermoon/pull/290)