### PR TITLE
Bump version to 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,7 +2318,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "undermoon"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["doyoubi"]
 edition = "2018"
 


### PR DESCRIPTION
# Release v0.4.5
This version fixes that brokers may reset migration tasks repeatedly after failover.

## Pull Requests
- [Fix migration task interrupted to v0.4](https://github.com/doyoubi/undermoon/pull/295)