### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "undermoon"
-version = "0.5.0-alpha.3"
+version = "0.5.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.5.0-alpha.3"
+version = "0.5.0"
 authors = ["doyoubi"]
 edition = "2018"
 


### PR DESCRIPTION
# Release v0.5.0
`0.5.0` introduces some small improvements based on the mature `0.4` version.

## Major improvements
- Support some popular `redis cluster` clients and add tests for them.
  - Redission
  - Jedis
  - go-redis
  - redis-py-cluster
- [Make some multi-key commands atomic during key migration](https://github.com/doyoubi/undermoon/pull/271) Now `EVAL` and `MSETNX` are atomic for each slot even during migration.
- [Add timeout for redis connections](https://github.com/doyoubi/undermoon/pull/279).
- [Support MSETNX](https://github.com/doyoubi/undermoon/pull/267) thanks to @traceming2 
- [Support BZPOPMIN and BZPOPMAX](https://github.com/doyoubi/undermoon/pull/237) thanks to @cfeitong 
- [Metadata Compression](https://github.com/doyoubi/undermoon/pull/241)

## Other Improvements
- [Support `UNDERMOON_DISABLE_FAILOVER` for testing](https://github.com/doyoubi/undermoon/pull/277)
- [Support HELLO command to explictly disable RESP version 3](https://github.com/doyoubi/undermoon/pull/269)
- [Support COMMAND command](https://github.com/doyoubi/undermoon/pull/266)
- [Amend 2-phase docker image building](https://github.com/doyoubi/undermoon/pull/254)

## Fixes
- [Fix migration task interrupted to v0.5](https://github.com/doyoubi/undermoon/pull/294)
- [Add retry for initializing broker data to v0.5](https://github.com/doyoubi/undermoon/pull/289)
