### PR TITLE
Send UMSYNC command no matter whether the key already exists

### DIFF
--- a/src/broker/migrate.rs
+++ b/src/broker/migrate.rs
@@ -272,10 +272,8 @@ impl<'a> MetaStoreMigrate<'a> {
 
     fn compact_slots(cluster: &mut ClusterStore) {
         for chunk in cluster.chunks.iter_mut() {
-            for slots in chunk.stable_slots.iter_mut() {
-                if let Some(slots) = slots {
-                    slots.get_mut_range_list().compact();
-                }
+            for slots in chunk.stable_slots.iter_mut().flatten() {
+                slots.get_mut_range_list().compact();
             }
             for slots in chunk.migrating_slots.iter_mut() {
                 for store in slots.iter_mut() {

--- a/src/migration/scan_task.rs
+++ b/src/migration/scan_task.rs
@@ -464,7 +464,7 @@ impl<T: CmdTask> MigratingTaskHandle<T> {
         self.task.stop();
         if let Some(sender) = self.stop_signal_sender.take() {
             if sender.send(()).is_err() {
-                warn!("failed to send stop signal");
+                info!("migrating task is already closed");
             }
         }
     }
@@ -671,7 +671,7 @@ impl ImportingTaskHandle {
         info!("stop importing task: {:?}", self.meta);
         if let Some(sender) = self.stop_signal_sender.take() {
             if sender.send(()).is_err() {
-                warn!("failed to send stop signal");
+                info!("importing task is already closed");
             }
         }
     }

--- a/src/proxy/cluster.rs
+++ b/src/proxy/cluster.rs
@@ -645,7 +645,7 @@ fn gen_cluster_nodes_helper(
                     .collect();
                 Some(ranges)
             })
-            .filter_map(|s| s)
+            .flatten()
             .flatten()
             .collect::<Vec<String>>()
             .join(" ");


### PR DESCRIPTION
The former implementation could result in this race condition:
- (1) Importing proxy handle query command
- (2) Migrating proxy migrates the key to the importing proxy and is pending.
- (3) Importing proxy pull data from src proxy and transferred the key and delete it in the migrating Redis.
- (4) Importing proxy handle DEL command for the same key. Since the key already exists, it does not send `UMSYNC` and delete the key.
- (5) (2) is now sending `RESTORE` and accidentally recover the key just deleted by (4).

This should be quite rare as I've never found out this result in tests but should be possible in theory.