### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,7 @@ checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "undermoon"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 authors = ["doyoubi"]
 edition = "2018"
 


### PR DESCRIPTION
# Release v0.6.0
`v0.6.0` has the following two 2 changes.

- Change API of `memory broker` and `UMCTL SETCLUSTER`.
- Improve migration and fix some inconsistent bugs during migration.

## API Change
- [Drop support for multiple clusters in a server proxy](https://github.com/doyoubi/undermoon/pull/280)
- [Remove 'free_nodes' of 'Proxy'](https://github.com/doyoubi/undermoon/pull/284)
- [Add version to UMCTL SETCLUSTER](https://github.com/doyoubi/undermoon/pull/285)
- [Fix empty response for broker http api](https://github.com/doyoubi/undermoon/pull/308)

## Migration Improvement
- [Add a fast path for UMSYNC](https://github.com/doyoubi/undermoon/pull/306)
- [Add migration stats](https://github.com/doyoubi/undermoon/pull/309)
- [Optimize WaitableTask](https://github.com/doyoubi/undermoon/pull/310)

## Bug Fixes
- [Add retry for initializing broker data](https://github.com/doyoubi/undermoon/pull/288)
- [Fix migration task interrupted](https://github.com/doyoubi/undermoon/pull/293)
- [Send UMSYNC command no matter whether the key already exists](https://github.com/doyoubi/undermoon/pull/300)
- [Fix the lock for delete commands during migration](https://github.com/doyoubi/undermoon/pull/305)

## Others
- [Add migration test docs](https://github.com/doyoubi/undermoon/pull/286)
- [Fix docker compose example](https://github.com/doyoubi/undermoon/pull/287)
- [Handle retry error in coordinator](https://github.com/doyoubi/undermoon/pull/296)
- [Uprade tokio to version 1. Change to use warp to replace actix-web](https://github.com/doyoubi/undermoon/pull/302)
- [Add migration testing script](https://github.com/doyoubi/undermoon/pull/304)