### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,7 @@ checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "undermoon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["doyoubi"]
 edition = "2018"
 

--- a/src/proxy/session.rs
+++ b/src/proxy/session.rs
@@ -258,7 +258,7 @@ where
         loop {
             match Pin::new(&mut reader).poll_next(cx) {
                 Poll::Ready(None) => {
-                    info!("Session is closed by peer");
+                    debug!("Session is closed by peer");
                     return Poll::Ready(Ok(()));
                 }
                 Poll::Ready(Some(req)) => {


### PR DESCRIPTION
# Release v0.6.1
`v0.6.0` mainly fixes a bug that data might not be migrated during scaling. This bug is introduced in an [optimization](https://github.com/doyoubi/undermoon/pull/306/files) in 0.6.0.

It also starts to use the latest format of `CLUSTER NODES` with the `cluster port` included.

## Bug Fixes
- [Fix scanning keys could possibly be skipped at the very beginning](https://github.com/doyoubi/undermoon/pull/313)

## Others
- [Upgrade to latest CLUSTER NODES format](https://github.com/doyoubi/undermoon/pull/314)
- [Reduce logs in undermoon-operator](https://github.com/doyoubi/undermoon/pull/315)