### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "undermoon"
-version = "0.6.2-dev0"
+version = "0.6.2"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undermoon"
-version = "0.6.2-dev0"
+version = "0.6.2"
 authors = ["doyoubi"]
 edition = "2018"
 


### PR DESCRIPTION
# Release v0.6.2
v0.6.2 is a minor release that starts to support client-side timeout.

## Features
- [Amend node id format in the output of CLUSTER NODES](https://github.com/doyoubi/undermoon/pull/323)
- [Add session timeout](https://github.com/doyoubi/undermoon/pull/319)

## Others
- [Add migration comparison test scripts](https://github.com/doyoubi/undermoon/pull/317)

